### PR TITLE
Very simple addition, convert tab characters to spaces.

### DIFF
--- a/src/DocxExtractor.php
+++ b/src/DocxExtractor.php
@@ -48,6 +48,7 @@ class DocxExtractor
 			'</w:r></w:p></w:tc><w:tc>' => " ",
 			'</w:r></w:p>' => "\r\n",
 			'</w:p>' => "\r\n",
+			'<w:tab/>' => " ",
 		]);
 
 		return strip_tags($text);


### PR DESCRIPTION
I find in my usage, I'd rather have a space than completely strip the tab character.
